### PR TITLE
Simplify journal api

### DIFF
--- a/src/controllers/opts.rs
+++ b/src/controllers/opts.rs
@@ -32,7 +32,7 @@ pub enum Command {
     /// Adds a new entry of a given type to the journal
     Add {
         #[structopt(subcommand)]
-        new_entry: EntryOpts
+        new_entry: EntryOpts,
     },
     /// Toggles the importance of the nth entry in the list
     Emph { index: usize },

--- a/src/controllers/opts.rs
+++ b/src/controllers/opts.rs
@@ -1,7 +1,7 @@
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-pub enum EntryType {
+pub enum EntryOpts {
     /// Add a new task entry
     Task {
         /// The task description
@@ -32,7 +32,7 @@ pub enum Command {
     /// Adds a new entry of a given type to the journal
     Add {
         #[structopt(subcommand)]
-        entry_type: EntryType,
+        new_entry: EntryOpts
     },
     /// Toggles the importance of the nth entry in the list
     Emph { index: usize },

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod views;
 
 use crate::{
     controllers::{Command, EntryType, Opt},
-    models::{Entry, Entries},
+    models::{Entry, EntryVariants},
     services::{Journalable, LocalDiskJournal},
     views::Application,
 };
@@ -22,13 +22,13 @@ fn main() {
         match command {
             Command::Add { entry_type } => match entry_type {
                 EntryType::Event { text } => {
-                    journal.append(Entry::new(Entries::Event, text))
+                    journal.append(Entry::new(EntryVariants::Event, text))
                 }
                 EntryType::Note { text } => {
-                    journal.append(Entry::new(Entries::Note, text))
+                    journal.append(Entry::new(EntryVariants::Note, text))
                 }
                 EntryType::Task { text } => {
-                    journal.append(Entry::new(Entries::Task, text))
+                    journal.append(Entry::new(EntryVariants::Task, text))
                 }
             },
             Command::Emph { index } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod views;
 
 use crate::{
     controllers::{Command, EntryType, Opt},
-    models::{Entries, Event, Note, Task},
+    models::{Entry, Entries},
     services::{Journalable, LocalDiskJournal},
     views::Application,
 };
@@ -22,13 +22,13 @@ fn main() {
         match command {
             Command::Add { entry_type } => match entry_type {
                 EntryType::Event { text } => {
-                    journal.append(Entries::Event(Event::new(text)));
+                    journal.append(Entry::new(Entries::Event, text))
                 }
                 EntryType::Note { text } => {
-                    journal.append(Entries::Note(Note::new(text)));
+                    journal.append(Entry::new(Entries::Note, text))
                 }
                 EntryType::Task { text } => {
-                    journal.append(Entries::Task(Task::new(text)));
+                    journal.append(Entry::new(Entries::Task, text))
                 }
             },
             Command::Emph { index } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod services;
 mod views;
 
 use crate::{
-    controllers::{Command, EntryType, Opt},
+    controllers::{Command, EntryOpts, Opt},
     models::{Entry, EntryVariants},
     services::{Journalable, LocalDiskJournal},
     views::Application,
@@ -20,14 +20,14 @@ fn main() {
     // Handle input!
     if let Some(command) = opt.command {
         match command {
-            Command::Add { entry_type } => match entry_type {
-                EntryType::Event { text } => {
+            Command::Add { new_entry } => match new_entry {
+                EntryOpts::Event { text } => {
                     journal.append(Entry::new(EntryVariants::Event, text))
                 }
-                EntryType::Note { text } => {
+                EntryOpts::Note { text } => {
                     journal.append(Entry::new(EntryVariants::Note, text))
                 }
-                EntryType::Task { text } => {
+                EntryOpts::Task { text } => {
                     journal.append(Entry::new(EntryVariants::Task, text))
                 }
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,15 +21,9 @@ fn main() {
     if let Some(command) = opt.command {
         match command {
             Command::Add { new_entry } => match new_entry {
-                EntryOpts::Event { text } => {
-                    journal.append(Entry::new(EntryVariants::Event, text))
-                }
-                EntryOpts::Note { text } => {
-                    journal.append(Entry::new(EntryVariants::Note, text))
-                }
-                EntryOpts::Task { text } => {
-                    journal.append(Entry::new(EntryVariants::Task, text))
-                }
+                EntryOpts::Event { text } => journal.append(Entry::new(EntryVariants::Event, text)),
+                EntryOpts::Note { text } => journal.append(Entry::new(EntryVariants::Note, text)),
+                EntryOpts::Task { text } => journal.append(Entry::new(EntryVariants::Task, text)),
             },
             Command::Emph { index } => {
                 journal.toggle_importance(index);

--- a/src/models/entries.rs
+++ b/src/models/entries.rs
@@ -1,15 +1,15 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Entries {
+pub enum EntryVariants {
     Note,
     Task,
     Event
 }
 
-impl Default for Entries {
+impl Default for EntryVariants {
     fn default() -> Self {
-        Entries::Note
+        EntryVariants::Note
     }
 }
 
@@ -19,14 +19,14 @@ pub struct Entry {
     pub content: String,
     pub completed: bool,
     pub cancelled: bool,
-    pub kind: Entries,
+    pub variant: EntryVariants,
     pub children: Vec<Entry>
 }
 
 impl Entry {
-    pub fn new(kind: Entries, content: String) -> Entry {
+    pub fn new(variant: EntryVariants, content: String) -> Entry {
         Entry {
-            kind,
+            variant,
             content,
             ..Default::default()
         }
@@ -39,20 +39,20 @@ pub trait JournalEntry {
 
 impl JournalEntry for Entry {
     fn render(&self) -> String {
-        match self.kind {
-            Entries::Event => format!(
+        match self.variant {
+            EntryVariants::Event => format!(
                 "{important} {symbol} {content}",
                 important = if self.important { "*" } else { " " },
                 symbol = "\u{26AC}",
                 content = self.content
             ),
-            Entries::Task => format!(
+            EntryVariants::Task => format!(
                 "{important} {symbol} {content}",
                 important = if self.important { "*" } else { " " },
                 symbol = if self.completed { "X" } else { "\u{2022}" },
                 content = self.content
             ),
-            Entries::Note => format!(
+            EntryVariants::Note => format!(
                 "{important} {symbol} {content}",
                 important = if self.important { "*" } else { " " },
                 symbol = "-",

--- a/src/models/entries.rs
+++ b/src/models/entries.rs
@@ -19,6 +19,7 @@ pub struct Entry {
     pub content: String,
     pub completed: bool,
     pub cancelled: bool,
+    #[serde(default)]
     pub variant: EntryVariants,
     pub children: Vec<Entry>
 }

--- a/src/models/entries.rs
+++ b/src/models/entries.rs
@@ -19,7 +19,6 @@ pub struct Entry {
     pub content: String,
     pub completed: bool,
     pub cancelled: bool,
-    #[serde(default)]
     pub variant: EntryVariants,
     pub children: Vec<Entry>
 }

--- a/src/models/entries.rs
+++ b/src/models/entries.rs
@@ -1,83 +1,62 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct Event {
-    pub important: bool,
-    pub content: String,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Entries {
+    Note,
+    Task,
+    Event
 }
 
-impl Event {
-    pub fn new(content: String) -> Event {
-        Event {
-            content,
-            ..Default::default()
-        }
+impl Default for Entries {
+    fn default() -> Self {
+        Entries::Note
     }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct Task {
+pub struct Entry {
     pub important: bool,
+    pub content: String,
     pub completed: bool,
     pub cancelled: bool,
-    pub content: String,
+    pub kind: Entries,
+    pub children: Vec<Entry>
 }
 
-impl Task {
-    pub fn new(content: String) -> Task {
-        Task {
+impl Entry {
+    pub fn new(kind: Entries, content: String) -> Entry {
+        Entry {
+            kind,
             content,
             ..Default::default()
         }
     }
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct Note {
-    pub important: bool,
-    pub content: String,
-}
-
-impl Note {
-    pub fn new(content: String) -> Note {
-        Note {
-            content,
-            ..Default::default()
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum Entries {
-    Event(Event),
-    Task(Task),
-    Note(Note),
 }
 
 pub trait JournalEntry {
     fn render(&self) -> String;
 }
 
-impl JournalEntry for Entries {
+impl JournalEntry for Entry {
     fn render(&self) -> String {
-        match self {
-            Entries::Event(item) => format!(
+        match self.kind {
+            Entries::Event => format!(
                 "{important} {symbol} {content}",
-                important = if item.important { "*" } else { " " },
+                important = if self.important { "*" } else { " " },
                 symbol = "\u{26AC}",
-                content = item.content
+                content = self.content
             ),
-            Entries::Task(item) => format!(
+            Entries::Task => format!(
                 "{important} {symbol} {content}",
-                important = if item.important { "*" } else { " " },
-                symbol = if item.completed { "X" } else { "\u{2022}" },
-                content = item.content
+                important = if self.important { "*" } else { " " },
+                symbol = if self.completed { "X" } else { "\u{2022}" },
+                content = self.content
             ),
-            Entries::Note(item) => format!(
+            Entries::Note => format!(
                 "{important} {symbol} {content}",
-                important = if item.important { "*" } else { " " },
+                important = if self.important { "*" } else { " " },
                 symbol = "-",
-                content = item.content
+                content = self.content
             ),
         }
     }

--- a/src/models/entries.rs
+++ b/src/models/entries.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub enum EntryVariants {
     Note,
     Task,
-    Event
+    Event,
 }
 
 impl Default for EntryVariants {
@@ -20,7 +20,7 @@ pub struct Entry {
     pub completed: bool,
     pub cancelled: bool,
     pub variant: EntryVariants,
-    pub children: Vec<Entry>
+    pub children: Vec<Entry>,
 }
 
 impl Entry {

--- a/src/services/journal.rs
+++ b/src/services/journal.rs
@@ -150,7 +150,7 @@ impl Journalable for LocalDiskJournal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{EntryVariants, Entry};
+    use crate::models::{Entry, EntryVariants};
     use std::fs::{remove_file, File};
 
     #[test]

--- a/src/services/journal.rs
+++ b/src/services/journal.rs
@@ -150,7 +150,7 @@ impl Journalable for LocalDiskJournal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Entries, Entry};
+    use crate::models::{EntryVariants, Entry};
     use std::fs::{remove_file, File};
 
     #[test]
@@ -164,7 +164,7 @@ mod tests {
     fn in_memory_journal_appends() {
         let mut journal = InMemoryJournal::new(None);
         journal.append(Entry::new(
-            Entries::Note,
+            EntryVariants::Note,
             "Learn how to write unit tests".to_string(),
         ));
         let entries = journal.list();
@@ -175,7 +175,7 @@ mod tests {
     fn in_memory_journal_removes() {
         let mut journal = InMemoryJournal::new(None);
         journal.append(Entry::new(
-            Entries::Note,
+            EntryVariants::Note,
             "Learn how to write unit tests".to_string(),
         ));
         assert_eq!(journal.list().len(), 1);
@@ -187,28 +187,26 @@ mod tests {
     fn in_memory_journal_toggles_importance() {
         let mut journal = InMemoryJournal::new(None);
         journal.append(Entry::new(
-            Entries::Note,
+            EntryVariants::Note,
             "Learn how to write unit tests".to_string(),
         ));
         journal.toggle_importance(0);
         assert_eq!(journal.list().len(), 1);
-        if let note = &journal.list()[0] {
-            assert_eq!(note.important, true);
-        }
+        let note = &journal.list()[0];
+        assert_eq!(note.important, true);
     }
 
     #[test]
     fn in_memory_journal_toggles_completion() {
         let mut journal = InMemoryJournal::new(None);
         journal.append(Entry::new(
-            Entries::Task,
+            EntryVariants::Task,
             "Learn how to write unit tests".to_string(),
         ));
         journal.toggle_completion(0);
         assert_eq!(journal.list().len(), 1);
-        if let task = &journal.list()[0] {
-            assert_eq!(task.completed, true);
-        }
+        let task = &journal.list()[0];
+        assert_eq!(task.completed, true);
     }
 
     #[test]
@@ -225,7 +223,7 @@ mod tests {
     fn on_disk_journal_appends() {
         let mut journal = LocalDiskJournal::new(Some("append-test".to_string()));
         journal.append(Entry::new(
-            Entries::Note,
+            EntryVariants::Note,
             "Learn how to write unit tests".to_string(),
         ));
         let entries = journal.list();
@@ -243,11 +241,11 @@ mod tests {
         let path = "remove-test".to_string();
         let mut journal = LocalDiskJournal::new(Some(path));
         journal.append(Entry::new(
-            Entries::Note,
+            EntryVariants::Note,
             "Learn how to write unit tests".to_string(),
         ));
         journal.append(Entry::new(
-            Entries::Note,
+            EntryVariants::Note,
             "Learn how to write integration tests".to_string(),
         ));
 
@@ -275,22 +273,20 @@ mod tests {
     fn on_disk_journal_toggles_importance() {
         let mut journal = LocalDiskJournal::new(Some("importance-test".to_string()));
         journal.append(Entry::new(
-            Entries::Note,
+            EntryVariants::Note,
             "Learn how to write unit tests".to_string(),
         ));
         journal.toggle_importance(0);
         assert_eq!(journal.list().len(), 1);
-        if let note = &journal.list()[0] {
-            assert_eq!(note.important, true);
-        }
+        let note = &journal.list()[0];
+        assert_eq!(note.important, true);
 
         let mut file = File::open(&journal.path).unwrap();
         let mut contents = String::new();
         file.read_to_string(&mut contents).unwrap();
         let disk_entries: Vec<Entry> = serde_yaml::from_str(&contents).unwrap();
-        if let note = &disk_entries[0] {
-            assert_eq!(note.important, true);
-        }
+        let note = &disk_entries[0];
+        assert_eq!(note.important, true);
         remove_file(&journal.path).unwrap();
     }
 
@@ -298,22 +294,20 @@ mod tests {
     fn on_disk_journal_toggles_completion() {
         let mut journal = LocalDiskJournal::new(Some("completion-test".to_string()));
         journal.append(Entry::new(
-            Entries::Task,
+            EntryVariants::Task,
             "Learn how to write unit tests".to_string(),
         ));
         journal.toggle_completion(0);
         assert_eq!(journal.list().len(), 1);
-        if let task = &journal.list()[0] {
-            assert_eq!(task.completed, true);
-        }
+        let task = &journal.list()[0];
+        assert_eq!(task.completed, true);
 
         let mut file = File::open(&journal.path).unwrap();
         let mut contents = String::new();
         file.read_to_string(&mut contents).unwrap();
         let disk_entries: Vec<Entry> = serde_yaml::from_str(&contents).unwrap();
-        if let task = &disk_entries[0] {
-            assert_eq!(task.completed, true);
-        }
+        let task = &disk_entries[0];
+        assert_eq!(task.completed, true);
         remove_file(&journal.path).unwrap();
     }
 }

--- a/src/views/application.rs
+++ b/src/views/application.rs
@@ -1,11 +1,11 @@
 use chrono::Local;
 use termion::{color, style};
 
-use crate::models::{Entries, JournalEntry};
+use crate::models::{Entry, JournalEntry};
 
 #[derive(Debug)]
 pub struct Application<'a> {
-    pub entries: &'a Vec<Entries>,
+    pub entries: &'a Vec<Entry>,
 }
 
 impl<'a> Application<'a> {


### PR DESCRIPTION
Combine the three types of entry (Note, Event, Task) into a single Entry struct, reducing boilerplate.